### PR TITLE
Point tsconfig to client and server TS files only

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -10,7 +10,8 @@
         "esModuleInterop": true,
         "noImplicitAny": false
     },
-    "include": [
-        "./src/**/*"
+    "files": [
+        "./src/index.ts",
+        "./src/client.tsx"
     ]
 }


### PR DESCRIPTION
Previous config defined a glob for all TS files. But only the files
required from the client or server root files need to be transpiled.

This prevents the whole project build failing due to one corrupt source
file that might not be committed to the repository, and isn't actually
used anywhere.