### PR TITLE
[WIP] Basemap tweaks

### DIFF
--- a/app/src/frontend/helpers.ts
+++ b/app/src/frontend/helpers.ts
@@ -75,9 +75,20 @@ function compareObjects(objA: object, objB: object): [object, object] {
     return [forward, reverse];
 }
 
+function toggleValue<T>(val: T, bothValues: readonly [T, T]): T {
+    if (val === bothValues[0]) {
+        return bothValues[1];
+    } else if (val === bothValues[1]) {
+        return bothValues[0];
+    } else {
+        throw new Error(`toggleValue: Supplied value (${val}) is not one of the values to toggle between (${bothValues})`);
+    }
+}
+
 export {
   sanitiseURL,
   arrayToDictionary,
   parseDate,
-  compareObjects
+  compareObjects,
+  toggleValue
 };

--- a/app/src/frontend/map/map.css
+++ b/app/src/frontend/map/map.css
@@ -47,3 +47,7 @@
         display: block;
     }
 }
+
+.basePane {
+    z-index: -1;
+}

--- a/app/src/frontend/types.ts
+++ b/app/src/frontend/types.ts
@@ -1,0 +1,8 @@
+
+export const ALL_MAP_MODES = ['basic', 'view', 'edit', 'multi-edit'] as const;
+export type MapMode = typeof ALL_MAP_MODES[number];
+
+export const EDIT_MAP_MODES: MapMode[] = ['edit', 'multi-edit'];
+
+export const ALL_MAP_THEMES = ['night', 'light'] as const;
+export type MapTheme = typeof ALL_MAP_THEMES[number];


### PR DESCRIPTION
- by default, change the base map from dark in view mode, to light in edit mode (this can be overwritten manually by using the pre-existing theme switcher button)
- hide the light/dark basemap on a zoomed out map
- synchronize the plain background color, shown when the basemap is hidden, with the dominant background colour of the light/night basemap, respectively
- temporarily added a slider to the interface to tweak the zoom level threshold for hiding the basemap - this can be used on a test site to tweak the threshold and see what works best