### PR TITLE
Fix TileLayer url bug, reorganise map layers

### DIFF
--- a/app/src/frontend/config/category-maps-config.ts
+++ b/app/src/frontend/config/category-maps-config.ts
@@ -1,4 +1,5 @@
 import { Category } from './categories-config';
+import { BuildingMapTileset } from './tileserver-config';
 
 export type LegendElement = {
     color: string;
@@ -16,7 +17,7 @@ export interface LegendConfig {
 }
 
 export interface CategoryMapDefinition {
-    mapStyle: string;
+    mapStyle: BuildingMapTileset;
     legend: LegendConfig;
 }
 

--- a/app/src/frontend/config/map-config.ts
+++ b/app/src/frontend/config/map-config.ts
@@ -1,0 +1,7 @@
+export const defaultMapPosition = {
+    lat: 51.5245255,
+    lng: -0.1338422,
+    zoom: 16
+};
+
+export type MapTheme = 'light' | 'night';

--- a/app/src/frontend/config/tileserver-config.ts
+++ b/app/src/frontend/config/tileserver-config.ts
@@ -1,0 +1,19 @@
+/**
+ * This file defines all the valid tileset names that can be obtained from the tilserver.
+ * Adjust the values here if modifying the list of styles in the tileserver.
+ */
+
+export type BuildingMapTileset = 'date_year' | 
+    'size_height' |
+    'construction_core_material' |
+    'location' |
+    'likes' |
+    'planning_combined' |
+    'sust_dec' |
+    'building_attachment_form' |
+    'landuse' |
+    'dynamics_demolished_count';
+
+export type SpecialMapTileset = 'base_light' | 'base_night' | 'highlight' | 'number_labels';
+
+export type MapTileset = BuildingMapTileset | SpecialMapTileset;

--- a/app/src/frontend/map/layers/building-base-layer.tsx
+++ b/app/src/frontend/map/layers/building-base-layer.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { TileLayer } from 'react-leaflet';
+
+import { MapTheme } from '../../config/map-config';
+import { MapTileset } from '../../config/tileserver-config';
+
+import {getTileLayerUrl } from './get-tile-layer-url';
+
+export function BuildingBaseLayer({ theme }: {theme: MapTheme}) {
+    const tileset = `base_${theme}` as const;
+
+    return <TileLayer
+                key={theme} /* needed because TileLayer url is not mutable in react-leaflet v3 */
+                url={getTileLayerUrl(tileset)}
+                minZoom={14}
+                maxZoom={19}
+                detectRetina={true}
+            />;
+}

--- a/app/src/frontend/map/layers/building-data-layer.tsx
+++ b/app/src/frontend/map/layers/building-data-layer.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { TileLayer } from 'react-leaflet';
+
+import { BuildingMapTileset } from '../../config/tileserver-config';
+
+import {getTileLayerUrl } from './get-tile-layer-url';
+
+export function BuildingDataLayer({tileset, revisionId} : { tileset: BuildingMapTileset, revisionId: string }) {
+    return <TileLayer
+                key={`${tileset}-${revisionId}`} /* needed because TileLayer url is not mutable in react-leaflet v3 */
+                url={getTileLayerUrl(tileset, {rev: revisionId})}
+                minZoom={9}
+                maxZoom={19}
+                detectRetina={true}
+            />;
+}

--- a/app/src/frontend/map/layers/building-highlight-layer.tsx
+++ b/app/src/frontend/map/layers/building-highlight-layer.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { TileLayer } from 'react-leaflet';
+
+import { BuildingMapTileset } from '../../config/tileserver-config';
+
+import { getTileLayerUrl } from './get-tile-layer-url';
+
+export function BuildingHighlightLayer({selectedBuildingId, baseTileset}: {selectedBuildingId: number, baseTileset: BuildingMapTileset}) {
+    return <TileLayer
+                key={`${selectedBuildingId}-${baseTileset}`} /* needed because TileLayer url is not mutable in react-leaflet v3 */
+                url={getTileLayerUrl('highlight', {highlight: `${selectedBuildingId}`, base: baseTileset})}
+                minZoom={13}
+                maxZoom={19}
+                detectRetina={true}
+            />;
+}

--- a/app/src/frontend/map/layers/building-numbers-layer.tsx
+++ b/app/src/frontend/map/layers/building-numbers-layer.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { TileLayer } from 'react-leaflet';
+
+import {getTileLayerUrl } from './get-tile-layer-url';
+
+export function BuildingNumbersLayer({revisionId}: {revisionId: string}) {
+    return <TileLayer
+                key={`numbers-${revisionId}`} /* needed because TileLayer url is not mutable in react-leaflet v3 */
+                url={getTileLayerUrl('number_labels', {rev: revisionId})}
+                minZoom={17}
+                maxZoom={19}
+                detectRetina={true}
+            />;
+}

--- a/app/src/frontend/map/layers/city-base-map-layer.tsx
+++ b/app/src/frontend/map/layers/city-base-map-layer.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { TileLayer } from 'react-leaflet';
+
+import { MapTheme } from '../../config/map-config';
+
+const OS_API_KEY = 'NVUxtY5r8eA6eIfwrPTAGKrAAsoeI9E9';
+
+/**
+ * Base raster layer for the map.
+ * @param theme map theme
+ */
+export function CityBaseMapLayer({theme}: {theme: MapTheme}) {
+
+    /**
+     * Ordnance Survey maps - UK / London specific
+     * (replace with appropriate base map for other cities/countries)
+     */
+    const key = OS_API_KEY;
+    const tilematrixSet = 'EPSG:3857';
+    const layer = theme === 'light' ? 'Light 3857' : 'Night 3857';
+    const baseUrl = `https://api2.ordnancesurvey.co.uk/mapping_api/v1/service/zxy/${tilematrixSet}/${layer}/{z}/{x}/{y}.png?key=${key}`;
+    const attribution = 'Building attribute data is © Colouring London contributors. Maps contain OS data © Crown copyright: OS Maps baselayers and building outlines. <a href=/ordnance-survey-licence.html>OS licence</a>';
+    
+    return <TileLayer
+        key={theme} /* needed because TileLayer.key is not mutabe in react-leaflet v3 */
+        url={baseUrl}
+        attribution={attribution}
+        maxNativeZoom={18}
+        maxZoom={19}
+        detectRetina={true}
+    />;
+}
+

--- a/app/src/frontend/map/layers/city-boundary-layer.tsx
+++ b/app/src/frontend/map/layers/city-boundary-layer.tsx
@@ -1,0 +1,17 @@
+import { GeoJsonObject } from 'geojson';
+import React, { useEffect, useState } from 'react';
+import { GeoJSON } from 'react-leaflet';
+
+import { apiGet } from '../../apiHelpers';
+
+export function CityBoundaryLayer() {
+    const [boundaryGeojson, setBoundaryGeojson] = useState<GeoJsonObject>(null);
+
+    useEffect(() => {
+        apiGet('/geometries/boundary-detailed.geojson')
+            .then(data => setBoundaryGeojson(data as GeoJsonObject));
+    }, []);
+
+    return boundaryGeojson &&
+        <GeoJSON data={boundaryGeojson} style={{color: '#bbb', fill: false}}/>;
+}

--- a/app/src/frontend/map/layers/get-tile-layer-url.ts
+++ b/app/src/frontend/map/layers/get-tile-layer-url.ts
@@ -1,0 +1,14 @@
+import { MapTileset } from '../../config/tileserver-config';
+
+/**
+ * Formats a CL tileserver URL for a tileset and a set of parameters
+ * @param tileset the name of the tileset
+ * @param parameters (optional) dictionary of parameter values
+ * @returns A string with the formatted URL
+ */
+export function getTileLayerUrl<T extends MapTileset = MapTileset>(tileset: T, parameters?: Record<string, string>) {
+    let paramString = parameters && new URLSearchParams(parameters).toString();
+    paramString = paramString == undefined ? '' : `?${paramString}`;
+
+    return `/tiles/${tileset}/{z}/{x}/{y}{r}.png${paramString}`;
+}


### PR DESCRIPTION
This fixes a bug caused by the recent react-leaflet update, where the URL prop of the TileLayer component is no longer mutable in v3, so map layers which depended on the layer reloading upon a URL change, needed to be adjusted.

The solution was to add appropriate key props to the layers, to force recreating the layers.

To simplify the management of layer reloading and to ensure some base layers don't re-appear above higher layers, the layer organisation was reworked using custom leaflet Panes. The file organisation was also changed to separate the logic for the different layers into their own components, rather than having everything in map.tsx