### PR TITLE
Correct tile renderer map bounds for London

### DIFF
--- a/app/src/tiles/rendererDefinition.ts
+++ b/app/src/tiles/rendererDefinition.ts
@@ -23,7 +23,7 @@ const STITCH_THRESHOLD = 12;
  * Hard-code extent so we can short-circuit rendering and return empty/transparent tiles outside the area of interest
  * bbox in CRS epsg:3857 in form: [w, s, e, n]
  */
-const EXTENT_BBOX: BoundingBox = [-61149.622628, 6667754.851372, 28128.826409, 6744803.375884];
+const EXTENT_BBOX: BoundingBox = [-61149.622628, 6667754.851372, 37183, 6744803.375884];
 
 const allLayersCacheSwitch = parseBooleanExact(process.env.CACHE_TILES) ?? true;
 const dataLayersCacheSwitch = parseBooleanExact(process.env.CACHE_DATA_TILES) ?? true;


### PR DESCRIPTION
This updates the hard-coded bounding box for London, to correctly render tiles for parts of London east of Upminster.