### PR TITLE
Document naming style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+## Branch naming
+
+Branch names should indicate type of work. For fixes also related issue should be mentioned.
+
+The format is `fix/123-short-description`, `feature/description` or `feature/123-short-description`.
+
+
+For example
+* [PR 648](https://github.com/colouring-london/colouring-london/pull/684) used branch `fix/681-land-use-edit` referencing [#681](https://github.com/colouring-london/colouring-london/issues/681)
+* [PR 625](https://github.com/colouring-london/colouring-london/pull/625) used branch `feature/verification`
+
+## Commits
+
+Commit messages should start from an upper case. So `Change public ownership sources field to array` is preferred oved `change public ownership sources field to array`.


### PR DESCRIPTION
It appears to be not documented currently.

@mz8i Have I missed/misunderstood something?

Is there preference between `feature/document_style` and `feature/document-style`?