### PR TITLE
Remove not needed ` signs

### DIFF
--- a/docs/setup-dev-environment.md
+++ b/docs/setup-dev-environment.md
@@ -152,8 +152,8 @@ root user profile. Don't forget to exit from root at the end.
 ```
 sudo su root
 export NODEJS_HOME=/usr/local/lib/node/node-v12.14.1/bin/
-export PATH=$NODEJS_HOME:$PATH`
-npm install -g npm@next`
+export PATH=$NODEJS_HOME:$PATH
+npm install -g npm@next
 exit
 ```
 


### PR DESCRIPTION
I am pretty that it is a documentation bug

(Also, next is apparently gone, though I have not 100% confirmed should it be just replaced with `npm@6` / `npm@7` / `latest` - https://github.com/npm/cli/issues/3876#issuecomment-940500240 )