### PR TITLE
Display unverified residential differently

### DIFF
--- a/app/map_styles/polygon.xml
+++ b/app/map_styles/polygon.xml
@@ -530,7 +530,11 @@
             <PolygonSymbolizer fill="#cccccc" />
         </Rule>
         <Rule>
-            <Filter>[current_landuse_order] = "Residential"</Filter>
+            <Filter>[current_landuse_order] = "Residential" and [verified_residential] = 0</Filter>
+            <PolygonSymbolizer fill="#6c6f8e" />
+        </Rule>
+        <Rule>
+            <Filter>[current_landuse_order] = "Residential" and [verified_residential] = 1</Filter>
             <PolygonSymbolizer fill="#4a54a6" />
         </Rule>
         <Rule>

--- a/app/src/api/services/building/verify.ts
+++ b/app/src/api/services/building/verify.ts
@@ -3,6 +3,7 @@ import { BaseBuilding } from '../../models/building';
 import * as buildingDataAccess from '../../dataAccess/building';
 import * as verifyDataAccess from '../../dataAccess/verify';
 import { DatabaseError } from '../../errors/general';
+import { expireBuildingTileCache } from './tileCache';
 
 function canVerify(key: string) {
     return buildingAttributesConfig[key].verify === true;
@@ -45,6 +46,7 @@ export async function verifyBuildingAttributes(buildingId: number, userId: strin
             throw new DatabaseError(msg);
         }
     }
+    expireBuildingTileCache(buildingId);
     return verified;
 }
 

--- a/app/src/frontend/config/category-maps-config.ts
+++ b/app/src/frontend/config/category-maps-config.ts
@@ -194,6 +194,7 @@ export const categoryMapsConfig: {[key in Category]: CategoryMapDefinition[]} = 
                 { color: '#e5050d', text: 'Mixed Use' },
                 { subtitle: 'Single use:'},
                 { color: '#4a54a6', text: 'Residential' },
+                { color: '#6c6f8e', text: 'Residential (unverified)' },
                 { color: '#ff8c00', text: 'Retail' },
                 { color: '#f5f58f', text: 'Industry & Business' },
                 { color: '#73ccd1', text: 'Community Services' },

--- a/app/src/tiles/dataDefinition.ts
+++ b/app/src/tiles/dataDefinition.ts
@@ -149,11 +149,20 @@ const LAYER_QUERIES = {
     landuse: `
         SELECT
             geometry_id,
-            current_landuse_order
+            current_landuse_order,
+            CASE WHEN (
+                    (verified_value = '["Dwellings"]' AND current_landuse_group::text = '{Dwellings}' AND attribute = 'current_landuse_group')
+                    OR
+                    (current_landuse_group::text != '{Dwellings}' AND current_landuse_order = 'Residential')
+                )
+                THEN 1 ELSE 0
+            END AS verified_residential
         FROM
             buildings
-        WHERE
-            current_landuse_order IS NOT NULL`,
+        LEFT OUTER JOIN
+            building_verification
+        ON
+            buildings.building_id = building_verification.building_id`,
     dynamics_demolished_count: `
         SELECT
             geometry_id,


### PR DESCRIPTION
Sadly, there is still a remaining issue: verifying building is not causing map to be updated.

Note that `verifyBuildingAttributes` is actually invalidating cache (a bit too eagerly, but I have not investigated that).

@mz8i Do you have any idea what may be going on here?

![screen07](https://user-images.githubusercontent.com/899988/147397708-ecb02fed-5a26-463c-84cf-3cd1303eb894.png)
